### PR TITLE
Add myth: Touching baby animals causes abandonment

### DIFF
--- a/school-myths-app/src/data/myths.js
+++ b/school-myths-app/src/data/myths.js
@@ -383,6 +383,26 @@ export const myths = [
         url: "https://www.health.harvard.edu/pain/does-cracking-knuckles-cause-arthritis"
       }
     ]
+  },
+  {
+    id: 20,
+    category: "Biology",
+    myth: "Touching a baby animal will cause its parents to abandon it because of human scent",
+    fact: "Most wild animals have a poor sense of smell and will not abandon their young if touched by humans.",
+    details: "This myth persists as well-intentioned advice to prevent people from interfering with wildlife, but it's not based on animal behavior. Most birds have a limited sense of smell and won't detect human scent. Mammals like deer and rabbits are primarily concerned with the physical presence of predators, not lingering scents. However, it's still best not to handle wild animals - not because parents will reject them, but because human interference can genuinely stress the animals or separate young from parents who are temporarily away gathering food.",
+    taughtDuring: { start: 1960, end: 2020 }, // Common wildlife advice given by parents and educators
+    references: [
+      {
+        title: "Fact or Fiction: Birds Abandon Young at Human Touch?",
+        source: "Scientific American",
+        url: "https://www.scientificamerican.com/article/fact-or-fiction-birds-abandon-young-at-human-touch/"
+      },
+      {
+        title: "If I touch a baby bird, will its parents reject it?",
+        source: "Alaska Department of Fish and Game",
+        url: "https://www.adfg.alaska.gov/index.cfm?adfg=wildlifenews.view_article&articles_id=426"
+      }
+    ]
   }
 ];
 

--- a/school-myths-app/src/data/myths.js
+++ b/school-myths-app/src/data/myths.js
@@ -388,7 +388,7 @@ export const myths = [
     id: 20,
     category: "Biology",
     myth: "Touching a baby animal will cause its parents to abandon it because of human scent",
-    fact: "Most wild animals have a poor sense of smell and will not abandon their young if touched by humans.",
+    fact: "Parents of most wild animals do not abandon their young solely because a human touched them; species typically rely on other cues and do not reject offspring based on human scent alone.",
     details: "This myth persists as well-intentioned advice to prevent people from interfering with wildlife, but it's not based on animal behavior. Most birds have a limited sense of smell and won't detect human scent. Mammals like deer and rabbits are primarily concerned with the physical presence of predators, not lingering scents. However, it's still best not to handle wild animals - not because parents will reject them, but because human interference can genuinely stress the animals or separate young from parents who are temporarily away gathering food.",
     taughtDuring: { start: 1960, end: 2020 }, // Common wildlife advice given by parents and educators
     references: [


### PR DESCRIPTION
- New Biology myth about human scent causing animal parents to abandon young
- Debunks common wildlife advice that's not based on animal behavior
- Teaching period: 1960-2020 (common advice from parents/educators)

Sources (both verified working):
- Scientific American: Fact or Fiction article on birds and human touch
- Alaska Department of Fish and Game: Wildlife biologist Q&A

Both sources are high-quality and meet project standards (government agency + established science publication)